### PR TITLE
Remove un-used constants and func

### DIFF
--- a/GasOptimisationFoundry/src/Gas.sol
+++ b/GasOptimisationFoundry/src/Gas.sol
@@ -3,14 +3,7 @@ pragma solidity 0.8.18;
 
 import "./Ownable.sol";
 
-// constants save on gas
-contract Constants {
-    uint256 constant tradeFlag = 1;
-    uint256 constant basicFlag = 0;
-    uint256 constant dividendFlag = 1;
-}
-
-contract GasContract is Ownable, Constants {
+contract GasContract is Ownable {
     // Constant totalSupply is set to 0, so that it cannot be updated
     uint256 private totalSupply = 0; // cannot be updated
     uint256 private paymentCounter = 0;
@@ -146,17 +139,6 @@ contract GasContract is Ownable, Constants {
         return balance;
     }
 
-    function getTradingMode() private pure returns (bool mode_) {
-        bool mode = false;
-        if (tradeFlag == 1 || dividendFlag == 1) {
-            mode = true;
-        } else {
-            mode = false;
-        }
-        return mode;
-    }
-
-
     function addHistory(address _updateAddress, bool _tradeMode)
         public
         returns (bool status_, bool tradeMode_)
@@ -237,8 +219,7 @@ contract GasContract is Ownable, Constants {
                 payments[_user][ii].admin = _user;
                 payments[_user][ii].paymentType = _type;
                 payments[_user][ii].amount = _amount;
-                bool tradingMode = getTradingMode();
-                addHistory(_user, tradingMode);
+                addHistory(_user, true);
                 emit PaymentUpdated(
                     senderOfTx,
                     _ID,


### PR DESCRIPTION
`getTradingMode` function returns always true, since the flags are constants (dividend and trade flags are always 1). So we can remove completely the function and Constants contract

```
    function getTradingMode() private pure returns (bool mode_) {
        bool mode = false;
        if (tradeFlag == 1 || dividendFlag == 1) {
            mode = true;
        } else {
            mode = false;
        }
        return mode;
    }
```