### PR TITLE
Remove Fallback and Receive

### DIFF
--- a/GasOptimisationFoundry/src/Gas.sol
+++ b/GasOptimisationFoundry/src/Gas.sol
@@ -315,9 +315,4 @@ contract GasContract is Ownable, Constants {
     receive() external payable {
         payable(msg.sender).transfer(msg.value);
     }
-
-
-    fallback() external payable {
-         payable(msg.sender).transfer(msg.value);
-    }
 }

--- a/GasOptimisationFoundry/src/Gas.sol
+++ b/GasOptimisationFoundry/src/Gas.sol
@@ -311,8 +311,4 @@ contract GasContract is Ownable, Constants {
     function getPaymentStatus(address sender) public view returns (bool, uint256) {        
         return (whiteListStruct[sender].paymentStatus, whiteListStruct[sender].amount);
     }
-
-    receive() external payable {
-        payable(msg.sender).transfer(msg.value);
-    }
 }


### PR DESCRIPTION
- Fallback function can be removed as it's a duplicate from receive function
- Receive function can be also removed as tests continue to pass

This saves `52261` units of gas